### PR TITLE
feat: add svg code textarea

### DIFF
--- a/src/components/SvgTo3D.vue
+++ b/src/components/SvgTo3D.vue
@@ -44,6 +44,25 @@ const shownShapes = computed(() => svgShapes.value.filter(i => i.depth))
 
 const inputRefs = ref<(unknown & { focus: () => void } | null)[]>([])
 
+const svgCode = ref('')
+
+watch(svgCode, (newCode) => {
+  const isNewCodeEmpty = !newCode || newCode.trim() === ''
+
+  isDefaultSvg.value = isNewCodeEmpty
+
+  if (isNewCodeEmpty)
+    return
+
+  if (!isValidSvg(newCode)) {
+    isDefaultSvg.value = true
+    console.error('Invalid SVG code')
+    return
+  }
+
+  mountSVG(newCode)
+})
+
 function mountSVG(svgData: string, customShapes?: (shapes: ShapeWithColor[], index: number) => ShapeWithColor[]) {
   isDefaultSvg.value = false
   svgShapes.value = createShapesWithColor(svgData, {
@@ -146,6 +165,20 @@ function handleMeshClick(index: number) {
 function handleColorChange(index: number, color: string) {
   svgShapes.value[index].color = new Color().setStyle(color)
 }
+
+function isValidSvg(code: string) {
+  if (!code || code.trim() === '')
+    return false
+
+  const lowerCode = code.toLowerCase()
+  const svgStart = lowerCode.indexOf('<svg')
+  const svgEnd = lowerCode.indexOf('</svg>')
+
+  return svgStart !== -1
+    && svgEnd !== -1
+    && svgStart < svgEnd
+    && (lowerCode.includes('viewbox') || lowerCode.includes('width') || lowerCode.includes('height'))
+}
 </script>
 
 <template>
@@ -183,12 +216,30 @@ function handleColorChange(index: number, color: string) {
         Convert SVG files to 3D models
       </p>
     </div>
-    <FileDropZone
-      v-model:filename="fileName"
-      :accept="['image/svg+xml']"
-      default-text="Click or drop SVG file"
-      @file-selected="handleFileSelected"
-    />
+    <div flex="~ col gap-2">
+      <FileDropZone
+        v-model:filename="fileName"
+        :accept="['image/svg+xml']"
+        default-text="Click or drop SVG file"
+        @file-selected="handleFileSelected"
+      />
+      <div flex="~ gap-2 items-center">
+        <hr flex-1>
+        <p text-center op-80>
+          OR
+        </p>
+        <hr flex-1>
+      </div>
+      <textarea
+        v-model="svgCode"
+        name="svg-code"
+        placeholder="Paste SVG code here"
+        bg="black/10 dark:white/20 hover:black/20 dark:hover:white/30"
+        p2
+        border
+        rounded
+      />
+    </div>
     <template v-if="svgShapes.length && !isDefaultSvg">
       <div flex="~ gap-2 items-center">
         <IconInput

--- a/src/components/SvgTo3D.vue
+++ b/src/components/SvgTo3D.vue
@@ -212,22 +212,22 @@ function isValidSvg(code: string) {
       </p>
     </div>
     <div flex="~ col gap-2">
-      <template v-if="!svgCode">
-        <FileDropZone
-          v-model:filename="fileName"
-          :accept="['image/svg+xml']"
-          default-text="Click or drop SVG file"
-          @file-selected="handleFileSelected"
-        />
-        <div flex="~ gap-2 items-center">
-          <hr flex-1>
-          <p text-center op-80>
-            OR
-          </p>
-          <hr flex-1>
-        </div>
-      </template>
+      <FileDropZone
+        v-if="!svgCode"
+        v-model:filename="fileName"
+        :accept="['image/svg+xml']"
+        default-text="Click or drop SVG file"
+        @file-selected="handleFileSelected"
+      />
+      <div v-if="!svgCode && !fileName" flex="~ gap-2 items-center">
+        <hr flex-1>
+        <p text-center op-80>
+          OR
+        </p>
+        <hr flex-1>
+      </div>
       <textarea
+        v-if="!fileName"
         v-model="svgCode"
         name="svg-code"
         placeholder="Paste SVG code here"

--- a/src/components/SvgTo3D.vue
+++ b/src/components/SvgTo3D.vue
@@ -48,15 +48,10 @@ const svgCode = ref('')
 
 watch(svgCode, (newCode) => {
   const isNewCodeEmpty = !newCode || newCode.trim() === ''
-
   isDefaultSvg.value = isNewCodeEmpty
 
-  if (isNewCodeEmpty)
-    return
-
-  if (!isValidSvg(newCode)) {
-    isDefaultSvg.value = true
-    console.error('Invalid SVG code')
+  if (isNewCodeEmpty || !isValidSvg(newCode)) {
+    loadDefaultSvg()
     return
   }
 
@@ -217,19 +212,21 @@ function isValidSvg(code: string) {
       </p>
     </div>
     <div flex="~ col gap-2">
-      <FileDropZone
-        v-model:filename="fileName"
-        :accept="['image/svg+xml']"
-        default-text="Click or drop SVG file"
-        @file-selected="handleFileSelected"
-      />
-      <div flex="~ gap-2 items-center">
-        <hr flex-1>
-        <p text-center op-80>
-          OR
-        </p>
-        <hr flex-1>
-      </div>
+      <template v-if="!svgCode">
+        <FileDropZone
+          v-model:filename="fileName"
+          :accept="['image/svg+xml']"
+          default-text="Click or drop SVG file"
+          @file-selected="handleFileSelected"
+        />
+        <div flex="~ gap-2 items-center">
+          <hr flex-1>
+          <p text-center op-80>
+            OR
+          </p>
+          <hr flex-1>
+        </div>
+      </template>
       <textarea
         v-model="svgCode"
         name="svg-code"


### PR DESCRIPTION
## Overview
Currently, we can only create 3D models by uploading SVG files. So, I have added a textarea for direct SVG code input.

## Scope of work
Added textarea for direct SVG code input with svg code validation.

## Screenshots
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/b6ab2241-476a-4215-a7a2-e84653cf3f3d" />
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/3cf527da-a282-40d8-aacf-f5c41b744436" />

## Note
Currently, we cannot clear the file after uploading. Should I add a clear button?