### PR TITLE
修复拖放不工作

### DIFF
--- a/src/components/FileDropZone.vue
+++ b/src/components/FileDropZone.vue
@@ -78,7 +78,7 @@ const { isOverDropZone } = useDropZone(dropZone, {
       return
     handleFiles(files)
   },
-  dataTypes: props.accept,
+  dataTypes: validateFileTypeMimes,
   multiple: props.multiple,
   preventDefaultForUnhandled: true,
 })
@@ -127,7 +127,7 @@ function handleFiles(files: File[]) {
  * @param file
  */
 function validateFileType(file: File) {
-  if (props.accept.includes('image/*') && file.type.startsWith('image/'))
+  if (validateFileTypeMimes([file.type]))
     return true
 
   // Handle files that have not been identified by type; we use their extension to verify.
@@ -139,6 +139,17 @@ function validateFileType(file: File) {
   }
 
   return props.accept.includes(file.type)
+}
+
+function validateFileTypeMimes(mimes: readonly string[]) {
+  for (const mime of mimes) {
+    if (props.accept.includes('image/*') && mime.startsWith('image/'))
+      continue
+    if (props.accept.includes(mime))
+      continue
+    return false
+  }
+  return true
 }
 
 // 计算显示文本

--- a/src/components/FileDropZone.vue
+++ b/src/components/FileDropZone.vue
@@ -43,12 +43,14 @@ const dropZone = ref<HTMLElement>()
 // 处理全局拖拽事件
 useEventListener('dragenter', (e) => {
   e.preventDefault()
+  const dataTransfer = e.dataTransfer
+  if (!dataTransfer?.items.length)
+    return
+  if (!validateFileTypeMimes(Array.from(dataTransfer.items).map(it => (it as DataTransferItem)?.type)))
+    return
   dragEnterCount.value++
   if (dragEnterCount.value === 1)
     isGlobalDragging.value = true
-  const dataTransfer = e.dataTransfer
-  if (!dataTransfer)
-    return
   dataTransfer.dropEffect = 'copy'
 })
 
@@ -69,6 +71,8 @@ useEventListener('dragleave', (e) => {
   dragEnterCount.value--
   if (dragEnterCount.value === 0)
     isGlobalDragging.value = false
+  if (dragEnterCount.value < 0)
+    dragEnterCount.value = 0
 })
 
 // 处理文件拖放


### PR DESCRIPTION
VueUse 的 useDropZone 是不支持 `['image/*']` 这种写法的，但是可以传入一个函数来判断是否是支持的 mime 类型
顺便优化了一下如果拖放不支持的文件到界面上就按钮就不会有变化提示用户放下文件

另外貌似拖入普通的 png 之类图片进去整个界面会卡死，这是还没完成的功能嘛