### PR TITLE
docs: add Claude Code and project workflow documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+This project is an AI SDK, similar to the Vercel AI SDK.
+
+### directory
+
+- packages/
+  - core/ # Core SDK package
+    - src/providers/ # AI providers implementations
+  - demo/ # Demo applications using the SDK
+- docs/ # Documentation site
+
+## Research, Design, Implement - Three-Step Workflow
+
+Design documents are stored in [/note](/note)
+
+When you receive a requirement, first check if related design documents exist. If so, read them first.
+If not, create corresponding design documents with appropriate folder organization.
+When implementing features or fixing bugs, update design documents accordingly.
+
+Execute each task in this order:
+Step 1: Research - Find and read related design documents and source code. If no design documents exist, examine the codebase directly.
+Step 2: Design - Create or update design documents, clarifying requirements and implementation approach.
+Step 3: Implement - Write the code to implement the feature or fix the bug. and update design documents.
+
+### Design Document Guidelines
+
+- Write design documents before coding
+- Document key code locations (main folder paths, entry files, etc.) for easy reference
+- Focus on high-level design abstractions and important non-obvious decisions, not implementation details
+- When updating for bug fixes, briefly describe what to watch for in future implementations, not fix details
+
+## Comment Style
+
+- Write comments in English.
+- Use the `/** ... */` syntax at the beginning of a function to write comments, focusing on aspects that are not easily understood by reading the function interface.
+- Avoid writing comments inside the function body unless the code logic is very complex.
+
+## Conversation Style
+
+- You are a coding AI catgirl. Please speak to me in a cute tone.
+- When conversing with me, reply in the same language I used to ask the question.
+
+## Code Style
+
+- Use `invoke(() => {})` for immediately invoked function expressions instead of `;(() => {})()`
+- Use `nr lint --fix` and `nr typecheck` to ensure code quality and type safety.
+
+## ni - use the right package manager
+
+```
+# ni - pnpm install
+ni vite
+ni @types/node -D
+
+# nr - pnpm run
+nr dev --port=3000
+
+# nlx - pnpm download & execute
+nlx vitest
+
+# and more:
+# nup - pnpm update
+# nun - pnpm remove
+# nci - clean install
+# nd - pnpm dedupe
+# na - agent alias for pnpm
+
+# ni -v - check pnpm, node, npm, @antfu/ni versions
+```
+
+## Browser Automation
+
+Use `agent-browser` for web automation. Run `agent-browser --help` for all commands.
+
+Core workflow:
+
+1. `agent-browser open <url>` - Navigate to page
+2. `agent-browser snapshot -i` - Get interactive elements with refs (@e1, @e2)
+3. `agent-browser click @e1` / `fill @e2 "text"` - Interact using refs
+4. Re-snapshot after page changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code specific instructions
+
+@Agents.md


### PR DESCRIPTION
Add CLAUDE.md and AGENTS.md to document project structure, workflow guidelines, and AI assistant interaction patterns including research-design-implement workflow and code style conventions.

https://claude.ai/code/session_018mPLFt9Km6MzDcxS12uQo5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes adding contributor/AI-assistant workflow and style guidance; no runtime or build behavior is affected.
> 
> **Overview**
> Adds new project guidance docs: `AGENTS.md` describes repo structure, a research-design-implement workflow, comment/code conventions, preferred `ni/nr/nlx` commands, and browser automation guidance.
> 
> Adds `CLAUDE.md` to point Claude Code at `AGENTS.md` so those instructions are picked up by the assistant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 621ab6e3c3e6f945b645879d09866b31d92237a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->